### PR TITLE
Fix sticky cards animation

### DIFF
--- a/src/components/sticky-cards/sticky-cards.tsx
+++ b/src/components/sticky-cards/sticky-cards.tsx
@@ -9,15 +9,19 @@ import {
 } from "react-icons/fi";
 
 export const StickyCards = () => {
-  const ref = useRef(null);
+  const containerRef = useRef(null);
   const { scrollYProgress } = useScroll({
-    target: ref,
-    offset: ["start start", "end start"],
+    container: containerRef,
+    offset: ["start start", "end end"],
   });
 
   return (
-    <>
-      <div ref={ref} className="relative">
+    <div 
+      ref={containerRef}
+      className="relative h-screen overflow-y-auto"
+    >
+      {/* Inner wrapper with extended height for scroll space */}
+      <div style={{ height: `${CARD_HEIGHT * CARDS.length}px` }}>
         {CARDS.map((c, idx) => (
           <Card
             key={c.id}
@@ -27,8 +31,7 @@ export const StickyCards = () => {
           />
         ))}
       </div>
-      <div className="h-screen bg-black" />
-    </>
+    </div>
   );
 };
 


### PR DESCRIPTION
## Summary
- Fixed sticky cards component animation by adding a proper scrollable container
- Cards now animate smoothly within their own scroll context instead of appearing statically

## Test plan
- [x] Navigate to the sticky cards section
- [x] Verify cards have their own scrollbar on the right
- [x] Confirm cards animate as you scroll within the container
- [x] Check that animation works independently of page scroll

🤖 Generated with [Claude Code](https://claude.ai/code)